### PR TITLE
Replace arbitrary sequence length kernel wrapper with a padding wrapper.

### DIFF
--- a/mlstm_kernels/torch/backend_module.py
+++ b/mlstm_kernels/torch/backend_module.py
@@ -14,7 +14,7 @@ from . import (
     get_mlstm_step_kernel,
 )
 from .kernel_wrappers import (
-    wrap_chunkwise__arbitrary_sequence_length,
+    wrap_chunkwise__arbitrary_sequence_length_with_padding,
     wrap_chunkwise__pad_zeros,
 )
 
@@ -107,7 +107,7 @@ class mLSTMBackend(nn.Module):
         self.step_kernel_fn = get_mlstm_step_kernel(config.step_kernel)
 
         self._inference_fn = partial(
-            wrap_chunkwise__arbitrary_sequence_length,
+            wrap_chunkwise__arbitrary_sequence_length_with_padding,
             mlstm_chunkwise_kernel=self.chunkwise_kernel_fn,
             mlstm_sequence_kernel=partial(
                 self.sequence_kernel_fn,

--- a/mlstm_kernels/torch/kernel_wrappers.py
+++ b/mlstm_kernels/torch/kernel_wrappers.py
@@ -74,6 +74,10 @@ def wrap_chunkwise__arbitrary_sequence_length(
 
     B, NH, S, DHQK = k.shape
     DHHV = v.shape[-1]
+    assert q.shape == (B, NH, S, DHQK)
+    assert v.shape == (B, NH, S, DHHV)
+    assert f.shape == (B, NH, S)
+    assert i.shape == (B, NH, S)
 
     chunk_sizes = []
     kcs = chunk_size
@@ -293,6 +297,10 @@ def wrap_chunkwise__arbitrary_sequence_length_with_padding(
 
     B, NH, S, DHQK = k.shape
     DHHV = v.shape[-1]
+    assert q.shape == (B, NH, S, DHQK), f"Expected q shape {(B, NH, S, DHQK)}, but got {q.shape}"
+    assert v.shape == (B, NH, S, DHHV), f"Expected v shape {(B, NH, S, DHHV)}, but got {v.shape}"
+    assert f.shape == (B, NH, S), f"Expected f shape {(B, NH, S)}, but got {f.shape}"
+    assert i.shape == (B, NH, S), f"Expected i shape {(B, NH, S)}, but got {i.shape}"
 
     c_state = (
         c_initial
@@ -313,7 +321,7 @@ def wrap_chunkwise__arbitrary_sequence_length_with_padding(
     if S > 1:
         # Pad the sequence to a multiple of the chunk size for the chunkwise kernel
         pad = ((S - 1) // chunk_size + 1) * chunk_size - S
-
+        # We pad the sequence dim S to the right. 
         h_out, (c_state, n_state, m_state) = mlstm_chunkwise_kernel(
             q=F.pad(q, (0, 0, 0, pad), value=0.0),
             k=F.pad(k, (0, 0, 0, pad), value=0.0),

--- a/mlstm_kernels/torch/kernel_wrappers.py
+++ b/mlstm_kernels/torch/kernel_wrappers.py
@@ -5,10 +5,12 @@ import logging
 from collections.abc import Callable
 
 import torch
+from torch.nn import functional as F
+
 
 LOGGER = logging.getLogger(__name__)
 
-
+# Note: This is very inefficient and should only be used for testing. Prefer the "with_padding" version.
 def wrap_chunkwise__arbitrary_sequence_length(
     mlstm_chunkwise_kernel: Callable,
     mlstm_sequence_kernel: Callable,
@@ -101,33 +103,55 @@ def wrap_chunkwise__arbitrary_sequence_length(
 
     if S > 1:
         # process the sequence length in chunks
-        LOGGER.debug(
-            "Regular Mode: Processing sequence length in chunks"
-        ) if enable_logging else None
+        (
+            LOGGER.debug("Regular Mode: Processing sequence length in chunks")
+            if enable_logging
+            else None
+        )
         h_outs = []
         seq_len_start_idx = 0
         for chunk_size_iter in chunk_sizes:
-            LOGGER.debug(
-                f"c_state.shape={c_state.shape}, n_state.shape={n_state.shape}, m_state.shape={m_state.shape}"
-            ) if enable_logging else None
-            LOGGER.debug(
-                f"c_state.stride(0)= {c_state.stride(0)}, c_state.stride(1)= {c_state.stride(1)}, c_state.stride(2)= {c_state.stride(2)}, matC_cur.stride(3)= {c_state.stride(3)}"
-            ) if enable_logging else None
+            (
+                LOGGER.debug(
+                    f"c_state.shape={c_state.shape}, n_state.shape={n_state.shape}, m_state.shape={m_state.shape}"
+                )
+                if enable_logging
+                else None
+            )
+            (
+                LOGGER.debug(
+                    f"c_state.stride(0)= {c_state.stride(0)}, c_state.stride(1)= {c_state.stride(1)}, c_state.stride(2)= {c_state.stride(2)}, matC_cur.stride(3)= {c_state.stride(3)}"
+                )
+                if enable_logging
+                else None
+            )
             remaining_seq_len = S - seq_len_start_idx
             num_chunks = remaining_seq_len // chunk_size_iter
-            LOGGER.debug(
-                f"chunk_size={chunk_size_iter}, remaining_seq_len={remaining_seq_len}"
-            ) if enable_logging else None
-            if remaining_seq_len < chunk_size_iter:
+            (
                 LOGGER.debug(
-                    f"Skipping chunk_size={chunk_size_iter} as remaining_seq_len={remaining_seq_len} < {chunk_size_iter}"
-                ) if enable_logging else None
+                    f"chunk_size={chunk_size_iter}, remaining_seq_len={remaining_seq_len}"
+                )
+                if enable_logging
+                else None
+            )
+            if remaining_seq_len < chunk_size_iter:
+                (
+                    LOGGER.debug(
+                        f"Skipping chunk_size={chunk_size_iter} as remaining_seq_len={remaining_seq_len} < {chunk_size_iter}"
+                    )
+                    if enable_logging
+                    else None
+                )
                 continue
             iter_seq_len = chunk_size_iter * num_chunks
             seq_len_idx = seq_len_start_idx + iter_seq_len
-            LOGGER.debug(
-                f"Mid OR Final: compute last state for seq[{seq_len_start_idx}:{seq_len_idx}], NC={num_chunks}, chunk_size={chunk_size_iter}"
-            ) if enable_logging else None
+            (
+                LOGGER.debug(
+                    f"Mid OR Final: compute last state for seq[{seq_len_start_idx}:{seq_len_idx}], NC={num_chunks}, chunk_size={chunk_size_iter}"
+                )
+                if enable_logging
+                else None
+            )
             h_out, (c_state, n_state, m_state) = mlstm_chunkwise_kernel(
                 q=q[..., seq_len_start_idx:seq_len_idx, :].contiguous(),
                 k=k[..., seq_len_start_idx:seq_len_idx, :].contiguous(),
@@ -145,17 +169,25 @@ def wrap_chunkwise__arbitrary_sequence_length(
             seq_len_start_idx += iter_seq_len
             h_outs.append(h_out)
             if remaining_seq_len % chunk_size_iter == 0:
-                LOGGER.debug(
-                    f"Finished processing sequence length in chunks, seq_len_start_idx={seq_len_start_idx}, S={S}"
-                ) if enable_logging else None
+                (
+                    LOGGER.debug(
+                        f"Finished processing sequence length in chunks, seq_len_start_idx={seq_len_start_idx}, S={S}"
+                    )
+                    if enable_logging
+                    else None
+                )
                 break
 
         remaining_seq_len = S - seq_len_start_idx
 
         if remaining_seq_len > 0:
-            LOGGER.debug(
-                f"Final: Recurrent step mode: compute last state for seq[{seq_len_start_idx}:{S}], remaining_seq_len={remaining_seq_len}"
-            ) if enable_logging else None
+            (
+                LOGGER.debug(
+                    f"Final: Recurrent step mode: compute last state for seq[{seq_len_start_idx}:{S}], remaining_seq_len={remaining_seq_len}"
+                )
+                if enable_logging
+                else None
+            )
             h_out, (c_state, n_state, m_state) = mlstm_sequence_kernel(
                 q=q[..., seq_len_start_idx:S, :].contiguous(),
                 k=k[..., seq_len_start_idx:S, :].contiguous(),
@@ -178,9 +210,131 @@ def wrap_chunkwise__arbitrary_sequence_length(
         # process the sequence length in a single step
         # while this case is also captured by the regular mode above,
         # it avoids the overhead of the loop and calls the step kernel directly
-        LOGGER.debug(
-            "Single step mode: Processing sequence length in a single step"
-        ) if enable_logging else None
+        (
+            LOGGER.debug(
+                "Single step mode: Processing sequence length in a single step"
+            )
+            if enable_logging
+            else None
+        )
+        # The step function does not want a sequence dimension
+        # qkv shape is (B, NH, DHQK/DHV)
+        # i, f shape is (B, NH, 1)
+        h_out, (c_state, n_state, m_state) = mlstm_step_kernel(
+            q=q.squeeze(2),
+            k=k.squeeze(2),
+            v=v.squeeze(2),
+            i=i,
+            f=f,
+            c=c_state,
+            n=n_state,
+            m=m_state,
+            eps=eps,
+        )
+        h_out = h_out[:, :, None, :]
+
+    if return_last_states:
+        return h_out, (c_state, n_state, m_state)
+    else:
+        return h_out
+
+
+def wrap_chunkwise__arbitrary_sequence_length_with_padding(
+    mlstm_chunkwise_kernel: Callable,
+    mlstm_sequence_kernel: Callable,  # unused
+    mlstm_step_kernel: Callable,
+    q: torch.Tensor,  # (B, NH, S, DHQK)
+    k: torch.Tensor,  # (B, NH, S, DHQK)
+    v: torch.Tensor,  # (B, NH, S, DHHV)
+    f: torch.Tensor,  # (B, NH, S)
+    i: torch.Tensor,  # (B, NH, S)
+    c_initial: torch.Tensor = None,  # (B, NH, DHQK, DHHV)
+    n_initial: torch.Tensor = None,  # (B, NH, DHQK)
+    m_initial: torch.Tensor = None,  # (B, NH, 1)
+    return_last_states: bool = True,
+    eps: float = 1e-6,
+    autocast_kernel_dtype: torch.dtype = torch.bfloat16,
+    chunk_size: int = 64,
+    dtype_state: torch.dtype = torch.float32,
+) -> (
+    torch.Tensor | tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]
+):  # matH (B, NH, S, DHHV), tuple[matC_state_last (B, NH, DHQK, DHHV), vecN_states_last (B, NH, DHQK), scaMinter_states_last (B, NH, 1)]
+    """This function computes the last hidden state and the matH outputs of the mLSTM, for arbitrary sequence lengths.
+
+    It does so, by padding the input sequence to a multiple of the chunk size and then calling the chunkwise kernel on the entire sequence.
+    The pad values are chosen so that the memory cell states are not updated for the padded positions and the output hidden states are zero for the padded positions.
+
+    Two kernels are used:
+    - mlstm_chunkwise_kernel: mlstm chunkwise kernels that processes chunks of a given chunk size in parallel.
+    - mlstm_step_kernel: mlstm kernel that processes a sequence length of 1 in a single step.
+
+    Args:
+        mlstm_chunkwise_kernel: The mLSTM chunkwise kernel that processes chunks of a given chunk size in parallel
+        mlstm_sequence_kernel: The mLSTM kernel that processes the remaining sequence length in a single step recurrence
+        q: The query tensor (B, NH, S, DHQK)
+        k: The key tensor (B, NH, S, DHQK)
+        v: The value tensor (B, NH, S, DHHV)
+        f: The forget gate tensor (B, NH, S)
+        i: The input gate tensor (B, NH, S)
+        c_initial: The initial cell state tensor (B, NH, DHQK, DHHV)
+        n_initial: The initial hidden state tensor (B, NH, DHQK)
+        m_initial: The initial memory state tensor (B, NH, 1)
+        return_last_states: If True, the function will return the last states of the mLSTM
+        eps: The epsilon value used for numerical stability
+        autocast_kernel_dtype: The dtype used for the kernel computation
+        chunk_size: The chunk size used for the chunkwise kernel
+        dtype_state: The dtype for the state. This function creates the initial state with this dtype.
+                     Note: Make sure you pass this dtype also to the kernel functions.
+
+    Returns:
+        The last hidden state tensor (B, NH, S, DHHV) or a tuple containing the last hidden state tensor and the last states of the mLSTM
+        Last states are (c (B, NH, DHQK, DHHV), n (B, NH, DHQK), m (B, NH, 1)).
+    """
+
+    B, NH, S, DHQK = k.shape
+    DHHV = v.shape[-1]
+
+    c_state = (
+        c_initial
+        if c_initial is not None
+        else torch.zeros(B, NH, DHQK, DHHV, device=k.device, dtype=dtype_state)
+    )
+    n_state = (
+        n_initial
+        if n_initial is not None
+        else torch.zeros(B, NH, DHQK, device=k.device, dtype=dtype_state)
+    )
+    m_state = (
+        m_initial
+        if m_initial is not None
+        else torch.zeros(B, NH, 1, device=k.device, dtype=dtype_state)
+    )
+
+    if S > 1:
+        # Pad the sequence to a multiple of the chunk size for the chunkwise kernel
+        pad = ((S - 1) // chunk_size + 1) * chunk_size - S
+
+        h_out, (c_state, n_state, m_state) = mlstm_chunkwise_kernel(
+            q=F.pad(q, (0, 0, 0, pad), value=0.0),
+            k=F.pad(k, (0, 0, 0, pad), value=0.0),
+            v=F.pad(v, (0, 0, 0, pad), value=0.0),
+            f=F.pad(f, (0, pad), value=25.0),  # Set forget gate to 1
+            i=F.pad(i, (0, pad), value=-25.0),  # Set input gate to 0
+            c_initial=c_state,
+            n_initial=n_state,
+            m_initial=m_state,
+            chunk_size=chunk_size,
+            return_last_states=True,
+            autocast_kernel_dtype=autocast_kernel_dtype,
+            eps=eps,
+        )
+        h_out = h_out[:, :, :S, :]
+
+    else:
+        assert (
+            S == 1
+        ), f"Received empty sequence (S={S}), require at least single element in the sequence."
+
         # The step function does not want a sequence dimension
         # qkv shape is (B, NH, DHQK/DHV)
         # i, f shape is (B, NH, 1)
@@ -227,26 +381,14 @@ def wrap_chunkwise__pad_zeros(
     )
 
     B, NH, S, DHQK = q.shape  # (B, NH, S, DHQK)
-    S_unpadded = S
-    # padding to chunk size for kernels
-    if S % chunk_size != 0:
-        S_padded = ((S + chunk_size - 1) // chunk_size) * chunk_size
-        q_pad = q.new_zeros(B, NH, S_padded, q.shape[3])
-        k_pad = k.new_zeros(B, NH, S_padded, k.shape[3])
-        v_pad = v.new_zeros(B, NH, S_padded, v.shape[3])
-        i_pad = i.new_zeros(B, NH, S_padded)
-        f_pad = f.new_zeros(B, NH, S_padded)
-        q_pad[:, :, :S_unpadded, :] = q
-        k_pad[:, :, :S_unpadded, :] = k
-        v_pad[:, :, :S_unpadded, :] = v
-        i_pad[:, :, :S_unpadded] = i
-        f_pad[:, :, :S_unpadded] = f
-    else:
-        q_pad = q
-        k_pad = k
-        v_pad = v
-        i_pad = i
-        f_pad = f
+
+    pad = ((S - 1) // chunk_size + 1) * chunk_size - S
+
+    q_pad = F.pad(q, (0, 0, 0, pad), value=0.0)
+    k_pad = F.pad(k, (0, 0, 0, pad), value=0.0)
+    v_pad = F.pad(v, (0, 0, 0, pad), value=0.0)
+    i_pad = F.pad(i, (0, pad), value=-25.0)  # Set forget gate to 1
+    f_pad = F.pad(f, (0, pad), value=25.0)  # Set input gate to 0
 
     matH = mlstm_chunkwise_kernel(
         q=q_pad,
@@ -263,5 +405,5 @@ def wrap_chunkwise__pad_zeros(
         chunk_size=chunk_size,
         **kwargs,
     )
-    matH = matH[:, :, :S_unpadded, :]
+    matH = matH[:, :, :S, :]
     return matH

--- a/tests/torch/template_test_arbitrary_sequence_length.py
+++ b/tests/torch/template_test_arbitrary_sequence_length.py
@@ -30,6 +30,7 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length(
     atol: float = 1e-5,
     rtol: float = 1e-5,
     eps: float = 1e-6,
+    kernel_wrapper: Callable = wrap_chunkwise__arbitrary_sequence_length,
 ):
     """Tests the wrap_chunkwise__arbitrary_sequence_length function.
 
@@ -58,11 +59,13 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length(
 
     # create the arbitrary sequence length chunkwise function
     chunkwise_arbitrary_seq_len_fn = partial(
-        wrap_chunkwise__arbitrary_sequence_length,
+        kernel_wrapper,
         mlstm_chunkwise_kernel=chunkwise_target,
-        mlstm_sequence_kernel=partial(sequence_target, dtype_state=getattr(torch, dtype_state)),
+        mlstm_sequence_kernel=partial(
+            sequence_target, dtype_state=getattr(torch, dtype_state)
+        ),
         mlstm_step_kernel=partial(step_target, dtype_state=getattr(torch, dtype_state)),
-        dtype_state=getattr(torch, dtype_state)
+        dtype_state=getattr(torch, dtype_state),
     )
 
     # run the chunkwise arbitrary seq_len fn
@@ -79,7 +82,9 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length(
         )
     )
 
-    assert c_last_cw_absl.dtype == getattr(torch, dtype_state), f"Got: {c_last_cw_absl.dtype}, Expected: {getattr(torch, dtype_state)}"
+    assert c_last_cw_absl.dtype == getattr(
+        torch, dtype_state
+    ), f"Got: {c_last_cw_absl.dtype}, Expected: {getattr(torch, dtype_state)}"
     assert n_last_cw_absl.dtype == getattr(torch, dtype_state)
     assert m_last_cw_absl.dtype == getattr(torch, dtype_state)
 
@@ -94,7 +99,6 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length(
     c_last_cw_absl = c_last_cw_absl.float().cpu().detach().numpy()
     n_last_cw_absl = n_last_cw_absl.float().cpu().detach().numpy()
     m_last_cw_absl = m_last_cw_absl.float().cpu().detach().numpy()
-
 
     # match baselines
     np.testing.assert_allclose(
@@ -159,6 +163,7 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length_single_step(
     atol: float = 1e-5,
     rtol: float = 1e-5,
     eps: float = 1e-6,
+    kernel_wrapper: Callable = wrap_chunkwise__arbitrary_sequence_length,
 ):
     """Tests the wrap_chunkwise__arbitrary_sequence_length function, for a single step."""
     torch.manual_seed(42)
@@ -187,7 +192,7 @@ def template_test_wrap_chunkwise__arbitrary_sequence_length_single_step(
 
     # create the arbitrary sequence length chunkwise function
     chunkwise_arbitrary_seq_len_fn = partial(
-        wrap_chunkwise__arbitrary_sequence_length,
+        kernel_wrapper,
         mlstm_chunkwise_kernel=chunkwise_target,
         mlstm_sequence_kernel=sequence_target,
         mlstm_step_kernel=step_target,

--- a/tests/torch/test_arbitrary_sequence_length.py
+++ b/tests/torch/test_arbitrary_sequence_length.py
@@ -23,6 +23,10 @@ from mlstm_kernels.torch.recurrent.native_sequence import (
     mlstm_recurrent_sequence__native_fw,
     mlstm_recurrent_sequence__triton_step_fused_fw,
 )
+from mlstm_kernels.torch.kernel_wrappers import (
+    wrap_chunkwise__arbitrary_sequence_length,
+    wrap_chunkwise__arbitrary_sequence_length_with_padding,
+)
 
 from .template_test_arbitrary_sequence_length import (
     template_test_wrap_chunkwise__arbitrary_sequence_length,
@@ -48,6 +52,13 @@ from .template_test_arbitrary_sequence_length import (
     ],
 )
 @pytest.mark.parametrize("device", ["cpu"])
+@pytest.mark.parametrize(
+    "kernel_wrapper",
+    [
+        wrap_chunkwise__arbitrary_sequence_length,
+        wrap_chunkwise__arbitrary_sequence_length_with_padding,
+    ],
+)
 def test_wrap_chunkwise__arbitrary_sequence_length_cpu(
     caplog,
     sequence_length: int,
@@ -58,6 +69,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_cpu(
     sequence_target: Callable,
     step_target: Callable,
     device: str,
+    kernel_wrapper: Callable,
 ):
     """Tests the wrap_chunkwise__arbitrary_sequence_length function.
 
@@ -83,6 +95,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_cpu(
         atol=1e-5,
         rtol=1e-5,
         eps=1e-6,
+        kernel_wrapper=kernel_wrapper,
     )
 
 
@@ -99,6 +112,13 @@ def test_wrap_chunkwise__arbitrary_sequence_length_cpu(
     ],
 )
 @pytest.mark.parametrize("device", ["cpu"])
+@pytest.mark.parametrize(
+    "kernel_wrapper",
+    [
+        wrap_chunkwise__arbitrary_sequence_length,
+        wrap_chunkwise__arbitrary_sequence_length_with_padding,
+    ],
+)
 def test_wrap_chunkwise__arbitrary_sequence_length_single_step_cpu(
     caplog,
     step_baseline: Callable,
@@ -106,6 +126,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_single_step_cpu(
     sequence_target: Callable,
     step_target: Callable,
     device: str,
+    kernel_wrapper: Callable,
 ):
     """Tests the wrap_chunkwise__arbitrary_sequence_length function.
 
@@ -128,6 +149,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_single_step_cpu(
         atol=1e-5,
         rtol=1e-5,
         eps=1e-6,
+        kernel_wrapper=kernel_wrapper,
     )
 
 
@@ -149,6 +171,13 @@ def test_wrap_chunkwise__arbitrary_sequence_length_single_step_cpu(
     ],
 )
 @pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize(
+    "kernel_wrapper",
+    [
+        wrap_chunkwise__arbitrary_sequence_length,
+        wrap_chunkwise__arbitrary_sequence_length_with_padding,
+    ],
+)
 def test_wrap_chunkwise__arbitrary_sequence_length_limit_chunk(
     caplog,
     sequence_length: int,
@@ -159,6 +188,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_limit_chunk(
     sequence_target: Callable,
     step_target: Callable,
     device: str,
+    kernel_wrapper: Callable,
 ):
     """Tests the wrap_chunkwise__arbitrary_sequence_length function.
 
@@ -184,6 +214,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_limit_chunk(
         atol=5e-2,
         rtol=1e-2,
         eps=1e-6,
+        kernel_wrapper=kernel_wrapper,
     )
 
 
@@ -203,6 +234,13 @@ def test_wrap_chunkwise__arbitrary_sequence_length_limit_chunk(
     ],
 )
 @pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize(
+    "kernel_wrapper",
+    [
+        wrap_chunkwise__arbitrary_sequence_length,
+        wrap_chunkwise__arbitrary_sequence_length_with_padding,
+    ],
+)
 def test_wrap_chunkwise__arbitrary_sequence_length_single_step_fused_step(
     caplog,
     B: int,
@@ -214,6 +252,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_single_step_fused_step(
     sequence_target: Callable,
     step_target: Callable,
     device: str,
+    kernel_wrapper: Callable,
 ):
     caplog.set_level(logging.DEBUG)
     template_test_wrap_chunkwise__arbitrary_sequence_length_single_step(
@@ -230,6 +269,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_single_step_fused_step(
         atol=1e-5,
         rtol=1e-5,
         eps=1e-6,
+        kernel_wrapper=kernel_wrapper,
     )
 
 
@@ -296,6 +336,7 @@ def test_wrap_chunkwise__arbitrary_sequence_length_xl_chunk(
         eps=1e-6,
     )
 
+
 # TODO(max) support configurable state dtype for chunkwise kernels.
 # Note: We expect this to fail since currently the triton chunkwise kernels.
 # always use float32 states for numerical stability during training
@@ -358,10 +399,11 @@ def test_wrap_chunkwise__absl_state_dtype_bf16_xfail(
         device=device,
         dtype_inputs="float32",
         dtype_state="bfloat16",
-        atol=5.7e-1, # only the case [75-32] needs this large tolerances
+        atol=5.7e-1,  # only the case [75-32] needs this large tolerances
         rtol=1e-2,
         eps=1e-6,
     )
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize(
@@ -422,7 +464,7 @@ def test_wrap_chunkwise__absl_state_dtype_bf16(
         device=device,
         dtype_inputs="float32",
         dtype_state="bfloat16",
-        atol=5.7e-1, # only the case [75-32] needs this large tolerances
+        atol=5.7e-1,  # only the case [75-32] needs this large tolerances
         rtol=1e-2,
         eps=1e-6,
     )

--- a/tests/torch/test_varlen.py
+++ b/tests/torch/test_varlen.py
@@ -1,0 +1,142 @@
+import torch
+import numpy as np
+from typing import Callable
+from mlstm_kernels.torch.chunkwise import (
+    mlstm_chunkwise__limit_chunk,
+    mlstm_chunkwise__xl_chunk,
+)
+
+from mlstm_kernels.torch.recurrent import (
+    mlstm_recurrent_sequence__native_fw,
+    mlstm_recurrent_sequence__triton_step_fused_fw,
+)
+
+
+def template_test_keep_state(
+    B: int,
+    NH: int,
+    S: int,
+    seq_pad: int,
+    DHQK: int,
+    DHHV: int,
+    chunkwise_kernel: Callable,
+    sequence_kernel: Callable,
+    chunk_size: int = 64,
+    dtype_inputs: str = "float32",
+    device: str = "cuda",
+    atol: float = 1e-3,
+    rtol: float = 1e-2,
+) -> None:
+
+    torch.manual_seed(42)
+
+    # baseline inputs
+    q = torch.randn(B, NH, S, DHQK)
+    k = torch.randn(B, NH, S, DHQK)
+    v = torch.randn(B, NH, S, DHHV)
+    i = torch.randn(B, NH, S)
+    f = 3.0 + torch.randn(B, NH, S)
+
+    # start with no (zero) initial state
+    c_initial = torch.zeros(B, NH, DHQK, DHHV)
+    n_initial = torch.zeros(B, NH, DHQK)
+    m_initial = torch.zeros(B, NH, 1)
+
+    # padded inputs
+    S_padded = S + seq_pad
+    qkv_pad_value = 0.0
+    igate_pad_value = -25.0
+    fgate_pad_value = 25.0
+
+    q_padded = torch.full((B, NH, S_padded, DHQK), fill_value=qkv_pad_value)
+    k_padded = torch.full((B, NH, S_padded, DHQK), fill_value=qkv_pad_value)
+    v_padded = torch.full((B, NH, S_padded, DHHV), fill_value=qkv_pad_value)
+    i_padded = torch.full((B, NH, S_padded), fill_value=igate_pad_value)
+    f_padded = torch.full((B, NH, S_padded), fill_value=fgate_pad_value)
+    q_padded[:, :, :S, :] = q
+    k_padded[:, :, :S, :] = k
+    v_padded[:, :, :S, :] = v
+    i_padded[:, :, :S] = i
+    f_padded[:, :, :S] = f
+
+    dtype_inputs = getattr(torch, dtype_inputs)
+    device = torch.device(device)
+    (q, k, v, i, f) = tuple(
+        map(lambda x: x.to(dtype=dtype_inputs, device=device), (q, k, v, i, f))
+    )
+    (c_initial, n_initial, m_initial) = tuple(
+        map(
+            lambda x: x.to(dtype=torch.float32, device=device),
+            (c_initial, n_initial, m_initial),
+        )
+    )
+
+    (q_padded, k_padded, v_padded, i_padded, f_padded) = tuple(
+        map(
+            lambda x: x.to(dtype=dtype_inputs, device=device),
+            (q_padded, k_padded, v_padded, i_padded, f_padded),
+        )
+    )
+
+    # run the chunkwise kernel with the padded inputs and initial states
+    h_padded, (c_last_padded, n_last_padded, m_last_padded) = chunkwise_kernel(
+        q=q_padded,
+        k=k_padded,
+        v=v_padded,
+        i=i_padded,
+        f=f_padded,
+        c_initial=c_initial,
+        n_initial=n_initial,
+        m_initial=m_initial,
+        return_last_states=True,
+        chunk_size=chunk_size,
+        autocast_kernel_dtype=torch.float32,
+        eps=1e-6,
+    )
+
+    # run the sequence kernel with the unpadded inputs and the last states from the padded chunkwise kernel
+    h_sequence, (c_last_sequence, n_last_sequence, m_last_sequence) = sequence_kernel(
+        q=q,
+        k=k,
+        v=v,
+        i=i,
+        f=f,
+        c_initial=c_initial,
+        n_initial=n_initial,
+        m_initial=m_initial,
+        return_last_states=True,
+        eps=1e-6,
+        dtype_state=torch.float32,
+    )
+
+    c_last_padded = c_last_padded.cpu().detach().numpy()
+    n_last_padded = n_last_padded.cpu().detach().numpy()
+    m_last_padded = m_last_padded.cpu().detach().numpy()
+
+    c_last_sequence = c_last_sequence.cpu().detach().numpy()
+    n_last_sequence = n_last_sequence.cpu().detach().numpy()
+    m_last_sequence = m_last_sequence.cpu().detach().numpy()
+
+    # compare the last states from the padded chunkwise kernel to the sequence kernel
+    np.testing.assert_allclose(c_last_padded, c_last_sequence, rtol=rtol, atol=atol)
+    np.testing.assert_allclose(n_last_padded, n_last_sequence, rtol=rtol, atol=atol)
+    np.testing.assert_allclose(m_last_padded, m_last_sequence, rtol=rtol, atol=atol)
+
+
+def test_keep_state():
+    """This tests verifies that we can pad variable sequences to a fixed length and still get the correct final states.
+    """
+    template_test_keep_state(
+        B=1,
+        NH=1,
+        S=50,
+        seq_pad=1024 - 50,
+        DHQK=64,
+        DHHV=128,
+        chunkwise_kernel=mlstm_chunkwise__limit_chunk,
+        sequence_kernel=mlstm_recurrent_sequence__triton_step_fused_fw,
+        dtype_inputs="float32",
+        device="cuda",
+        atol=1e-3,
+        rtol=5e-3,
+    )

--- a/tests/torch/test_varlen.py
+++ b/tests/torch/test_varlen.py
@@ -1,13 +1,14 @@
+#  Copyright (c) NXAI GmbH.
+#  This software may be used and distributed according to the terms of the NXAI Community License Agreement.
+
 import torch
 import numpy as np
-from typing import Callable
+from collections.abc import Callable
 from mlstm_kernels.torch.chunkwise import (
     mlstm_chunkwise__limit_chunk,
-    mlstm_chunkwise__xl_chunk,
 )
 
 from mlstm_kernels.torch.recurrent import (
-    mlstm_recurrent_sequence__native_fw,
     mlstm_recurrent_sequence__triton_step_fused_fw,
 )
 
@@ -27,7 +28,6 @@ def template_test_keep_state(
     atol: float = 1e-3,
     rtol: float = 1e-2,
 ) -> None:
-
     torch.manual_seed(42)
 
     # baseline inputs
@@ -124,8 +124,7 @@ def template_test_keep_state(
 
 
 def test_keep_state():
-    """This tests verifies that we can pad variable sequences to a fixed length and still get the correct final states.
-    """
+    """This tests verifies that we can pad variable sequences to a fixed length and still get the correct final states."""
     template_test_keep_state(
         B=1,
         NH=1,


### PR DESCRIPTION
This PR replaces the default `wrap_chunkwise__arbitrary_sequence_length` kernel wrapper for inference (more precisely for prefill with the `wrap_chunkwise__arbitrary_sequence_length_with_padding` kernel wrapper. 

We keep the old wrapper functions for reference. 

In short, the new wrapper relies on the insight that we can pad the qkv sequence from the right with zeros and set the forget gate to 1 and the input gate to 0, so that the final memory state is maintained over the padding time steps. 

This is more efficient than the previous arbitrary sequence length kernel wrapper, which relied on a sequence of chunkwise and step kernel calls to precisely match the arbitrary sequence length.