### PR TITLE
Avoid batch-size specialization in limit-chunk kernels

### DIFF
--- a/mlstm_kernels/triton/chunkwise/limit_chunk/bw_kernel_parallel.py
+++ b/mlstm_kernels/triton/chunkwise/limit_chunk/bw_kernel_parallel.py
@@ -29,7 +29,7 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["B"])
 def mlstm_chunkwise__parallel_bw_dQKV_kernel(
     matQ,  # (B, NH, S, DHQK)
     matK,  # (B, NH, S, DHQK)
@@ -68,7 +68,7 @@ def mlstm_chunkwise__parallel_bw_dQKV_kernel(
     str_matDeltaC_states_B_NH,
     str_matDeltaC_states_NCDHQK,
     str_matDeltaC_states_DHHV,
-    B: tl.constexpr,
+    B,
     NH: tl.constexpr,
     S: tl.constexpr,
     DHQK: tl.constexpr,

--- a/mlstm_kernels/triton/chunkwise/limit_chunk/bw_kernel_recurrent.py
+++ b/mlstm_kernels/triton/chunkwise/limit_chunk/bw_kernel_recurrent.py
@@ -29,7 +29,7 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["B"])
 def mlstm_chunkwise__recurrent_bw_dC_kernel(
     matQ,  # (B, NH, S, DHQK)
     vecB,  # (B, NH, NC, L)
@@ -61,7 +61,7 @@ def mlstm_chunkwise__recurrent_bw_dC_kernel(
     str_matDeltaC_states_B_NH,
     str_matDeltaC_states_NCDHQK,
     str_matDeltaC_states_DHHV,
-    B: tl.constexpr,
+    B,
     NH: tl.constexpr,
     S: tl.constexpr,
     DHQK: tl.constexpr,

--- a/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_parallel.py
+++ b/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_parallel.py
@@ -29,7 +29,7 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["B"])
 def mlstm_chunkwise__parallel_fw_H_kernel(
     matQ,  # (B, NH, S, DHQK)
     matK,  # (B, NH, S, DHQK)
@@ -60,7 +60,7 @@ def mlstm_chunkwise__parallel_fw_H_kernel(
     str_vecBI_L,
     str_vecMN_B_NH,
     str_vecMN_S,
-    B: tl.constexpr,
+    B,
     NH: tl.constexpr,
     S: tl.constexpr,
     DHQK: tl.constexpr,

--- a/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_recurrent.py
+++ b/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_recurrent.py
@@ -29,7 +29,7 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["B"])
 def mlstm_chunkwise__recurrent_fw_C_kernel(
     matK,  # (B, NH, S, DHQK)
     matV,  # (B, NH, S, DHHV)
@@ -63,7 +63,7 @@ def mlstm_chunkwise__recurrent_fw_C_kernel(
     str_vecNinitial_B_NH,
     str_vecNinitial_DHQK,
     str_scaMinterinitial_B_NH,
-    B: tl.constexpr,
+    B,
     NH: tl.constexpr,
     S: tl.constexpr,
     DHQK: tl.constexpr,

--- a/tests/torch/chunkwise/test_chunkwise_triton_limit_chunk.py
+++ b/tests/torch/chunkwise/test_chunkwise_triton_limit_chunk.py
@@ -6,6 +6,12 @@ import logging
 import pytest
 import torch
 
+from mlstm_kernels.triton.chunkwise.limit_chunk import (
+    mlstm_chunkwise__parallel_bw_dQKV_kernel,
+    mlstm_chunkwise__parallel_fw_H_kernel,
+    mlstm_chunkwise__recurrent_bw_dC_kernel,
+    mlstm_chunkwise__recurrent_fw_C_kernel,
+)
 from mlstm_kernels.torch.chunkwise.triton_limit_chunk import (
     mlstm_chunkwise__limit_chunk,
 )
@@ -18,6 +24,21 @@ from ...conftest import final_combinations
 LOGGER = logging.getLogger(__name__)
 
 TEST_FOLDER_NAME_PREFIX = "chunkwise-triton_limit_chunk"
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        mlstm_chunkwise__recurrent_fw_C_kernel,
+        mlstm_chunkwise__parallel_fw_H_kernel,
+        mlstm_chunkwise__recurrent_bw_dC_kernel,
+        mlstm_chunkwise__parallel_bw_dQKV_kernel,
+    ],
+)
+def test_batch_size_does_not_specialize(kernel):
+    batch_param = next(param for param in kernel.params if param.name == "B")
+    assert not batch_param.is_constexpr
+    assert batch_param.do_not_specialize
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No GPU available.")


### PR DESCRIPTION
While running a hyperparameter sweep, I noticed that the kernels were recompiled whenever the batch size changed, which added significant overhead.
The batch size is not used inside these four limit-chunk kernels, but it was declared as tl.constexpr. This change makes B a regular argument and disables specialization for it. Everything else stayed the same and I also added a small test covering all four kernels. 