### PR TITLE
Add PyPI publishing workflow and bump version to 2.0.5

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,59 @@
+# https://docs.github.com/en/actions/tutorials/build-and-test-code/python#publishing-to-pypi
+
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+
+    needs:
+      - release-build
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # # Dedicated environments with protections for publishing are strongly recommended.
+    # environment:
+    #   name: pypi
+    #   # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+    #   # url: https://pypi.org/p/YOURPROJECT
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v5
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,11 +42,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 
-    # # Dedicated environments with protections for publishing are strongly recommended.
-    # environment:
-    #   name: pypi
-    #   # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-    #   # url: https://pypi.org/p/YOURPROJECT
+    # Dedicated environments with protections for publishing are strongly recommended.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mlstm-kernels/
 
     steps:
       - name: Retrieve release distributions

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,4 +56,4 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33

--- a/mlstm_kernels/__init__.py
+++ b/mlstm_kernels/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright (c) NXAI GmbH.
 #  This software may be used and distributed according to the terms of the NXAI Community License Agreement.
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlstm_kernels"
-version = "2.0.4"
+version = "2.0.5"
 authors = [
   { name="Maximilian Beck", email="beck@ml.jku.at" },
   { name="Korbinian Poeppel", email="poeppel@ml.jku.at" },


### PR DESCRIPTION
Adds a GitHub Actions workflow to build package distributions and publish them to PyPI when a release is published or the workflow is manually triggered. Publishing uses OIDC authentication. Bumps the package version from 2.0.4 to 2.0.5.

Validation: `git diff --cached --check` passed before committing. The publishing workflow has not been executed.
