### PR TITLE
fix dtype mismatch: qk_scale to float32

### DIFF
--- a/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_parallel.py
+++ b/mlstm_kernels/triton/chunkwise/limit_chunk/fw_kernel_parallel.py
@@ -156,7 +156,7 @@ def mlstm_chunkwise__parallel_fw_H_kernel(
         matK_val = tl.load(matK_ptr, boundary_check=(0, 1)).to(DTYPE)
 
         # accumulate matS (L, L)
-        matS_val += tl.dot(matQ_val, matK_val) * qk_scale
+        matS_val += (tl.dot(matQ_val, matK_val) * qk_scale).to(DTYPE)
 
         # compute matQbar (L, siz_b_DHQK)
         # tl.static_print("matQ_val", matQ_val)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlstm_kernels"
-version = "2.0.5"
+version = "2.0.6"
 authors = [
   { name="Maximilian Beck", email="beck@ml.jku.at" },
   { name="Korbinian Poeppel", email="poeppel@ml.jku.at" },


### PR DESCRIPTION
Before qk_scale under `@torch.compile` converts to float64 which causes `dtype` mismatch.
This PR fixes it and allows to use `@torch.compile` for mlstm_kernels.